### PR TITLE
Fix failure when a `name_keys` contains space

### DIFF
--- a/lib/fluent/plugin/out_growthforecast.rb
+++ b/lib/fluent/plugin/out_growthforecast.rb
@@ -77,13 +77,14 @@ class Fluent::GrowthForecastOutput < Fluent::Output
   end
 
   def format_url(tag, name)
+    name_esc = URI.escape(name)
     case @tag_for
     when :ignore
-      @gfurl + @section + '/' + name
+      @gfurl + @section + '/' + name_esc
     when :section
-      @gfurl + tag + '/' + name
+      @gfurl + tag + '/' + name_esc
     when :name_prefix
-      @gfurl + @section + '/' + tag + '_' + name
+      @gfurl + @section + '/' + tag + '_' + name_esc
     end
   end
 


### PR DESCRIPTION
This plugin crush, when a `name_keys` contains space like following.

```
type growthforecast
gfapi_url http://localhost:5000/api/
service foo
section bar
name_keys Available Bytes
```

To prevent this, I added `URI#escape`.
