### PR TITLE
sslとverify_sslオプションを追加しました

### DIFF
--- a/lib/fluent/plugin/out_growthforecast.rb
+++ b/lib/fluent/plugin/out_growthforecast.rb
@@ -11,6 +11,9 @@ class Fluent::GrowthForecastOutput < Fluent::Output
   config_param :service, :string
   config_param :section, :string, :default => nil
 
+  config_param :ssl, :bool, :default => false
+  config_param :verify_ssl, :bool, :default => false
+
   config_param :name_keys, :string, :default => nil
   config_param :name_key_pattern, :string, :default => nil
 
@@ -107,7 +110,11 @@ class Fluent::GrowthForecastOutput < Fluent::Output
         req.basic_auth(@username, @password)
       end
       req.set_form_data({'number' => value.to_i, 'mode' => @mode.to_s})
-      res = Net::HTTP.new(url.host, url.port).start {|http| http.request(req) }
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = @ssl
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE unless @verify_ssl
+
+      res = http.start {|http| http.request(req) }
     rescue IOError, EOFError, SystemCallError
       # server didn't respond
       $log.warn "Net::HTTP.post_form raises exception: #{$!.class}, '#{$!.message}'"


### PR DESCRIPTION
GrowthForeCast側がHTTPSの時にSSLを使用します。証明書チェインの検証はデフォルトで無効にしています。
