### PR TITLE
add choice 'service_and_name' for 'tag_for' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ Version v0.2.0 or later, this plugin uses HTTP connection keep-alive for a batch
     
 * tag\_for
 
-    Either of `name_prefix`, `section`, `service`, or `ignore`. Default is `name_prefix`. 
+    Either of `name_prefix`, `section`, `service`, `service_and_name`, or `ignore`. Default is `name_prefix`. 
 
     * `name_prefix` uses the tag name as a graph\_name prefix. 
     * `section` uses the tag name as a section\_name.
     * `service` uses the tag name as a service\_name.
+    * `service_and_name` uses the tag name as a service\_name and graph\_name prefix.
     * `ignore` uses the tag name for nothing.
     
 * remove\_prefix

--- a/lib/fluent/plugin/out_growthforecast.rb
+++ b/lib/fluent/plugin/out_growthforecast.rb
@@ -76,14 +76,15 @@ class Fluent::GrowthForecastOutput < Fluent::Output
                when 'ignore' then :ignore
                when 'section' then :section
                when 'service' then :service
+               when 'service_and_name' then :service_and_name
                else
                  :name_prefix
                end
     if @tag_for != :section and @section.nil?
       raise Fluent::ConfigError, "section parameter is needed when tag_for is not 'section'"
     end
-    if @tag_for != :service and @service.nil?
-      raise Fluent::ConfigError, "service parameter is needed when tag_for is not 'service'"
+    if @tag_for != :service and @tag_for != :service_and_name and @service.nil?
+      raise Fluent::ConfigError, "service parameter is needed when tag_for is not 'service' or 'service_and_name'"
     end
 
     if @remove_prefix
@@ -151,6 +152,8 @@ class Fluent::GrowthForecastOutput < Fluent::Output
       @gfapi_url + URI.escape(@service + '/' + tag + '/' + name)
     when :service
       @gfapi_url + URI.escape(tag + '/' + @section + '/' + name)
+    when :service_and_name
+      @gfapi_url + URI.escape(tag + '/' + @section + '/' + tag + '_' + name)
     when :name_prefix
       @gfapi_url + URI.escape(@service + '/' + @section + '/' + tag + '_' + name)
     end


### PR DESCRIPTION
This pull-req enhances `tag_for` option to add 'service_and_name'.
It is very useful for these points.
- it could use service name from tag and graph name together.
- on embedding image at external page, it is user friendly for including service name in the image.

---
### sample for `tag_for service_and_name`

![gf-tag_for-service_and_name](https://f.cloud.github.com/assets/1734549/1066201/bad137f0-13ad-11e3-8650-3cdea34fcce4.png)

---
### sample for `tag_for service`

![gf-tag_for-service](https://f.cloud.github.com/assets/1734549/1066202/baf38b2a-13ad-11e3-9027-5b84a6a80af3.png)
