### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-growthforecast
+# fluent-plugin-growthforecast, a plugin for [Fluentd](http://fluentd.org)
 
 ## GrowthForecastOutput
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
