### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# fluent-plugin-growthforecast, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-growthforecast 
 
 ## GrowthForecastOutput
 
-Plugin to output numbers(metrics) to 'GrowthForecast', metrics drawing tool over HTTP.
+[Fluentd](http://fluentd.org) plugin to output numbers(metrics) to 'GrowthForecast', metrics drawing tool over HTTP.
 
 About GrowthForecast, see:
 * Github: https://github.com/kazeburo/growthforecast


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
