### PR TITLE
add datetime_format option for use to both of Growthforecast and HRForecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ Version v0.2.0 or later, this plugin uses HTTP connection keep-alive for a batch
 * mode
 
     The graph mode (either of `gauge`, `count`, or `modified`). Just same as `mode` of GrowthForecast POST parameter. Default is `gauge`. 
-   
-* hrforecast_datetime_format
 
-    For HRForecast datetime parameter. HRForecast is yet another data visualize tool has WebAPI like GrowthForecast.
-    datetime POST parameter formatted by this option is used instead of mode paramter if specified. (Default is not specified)
+* datetime_format
+
+    Send `datetime` POST parameter too if specified. (Default is not specified)
+    Time is formatted by this option, e.g. `%Y-%m-%d %H:%M:%S %z`
+    (see http://ruby-doc.org/core/Time.html#method-i-strftime)
 
 * keepalive
 

--- a/lib/fluent/plugin/out_growthforecast.rb
+++ b/lib/fluent/plugin/out_growthforecast.rb
@@ -21,7 +21,7 @@ class Fluent::GrowthForecastOutput < Fluent::Output
   config_param :name_key_pattern, :string, :default => nil
 
   config_param :mode, :string, :default => 'gauge' # or count/modified
-  config_param :hrforecast_datetime_format, :string, :default => nil
+  config_param :datetime_format, :string, :default => nil
 
   config_param :remove_prefix, :string, :default => nil
   config_param :tag_for, :string, :default => 'name_prefix' # or 'ignore' or 'section' or 'service'
@@ -202,12 +202,14 @@ class Fluent::GrowthForecastOutput < Fluent::Output
     if @keepalive
       req['Connection'] = 'Keep-Alive'
     end
-    value = @enable_float_number ? value.to_f : value.to_i
-    if @hrforecast_datetime_format
-      req.set_form_data({'number' => value, 'datetime' => Time.at(time).strftime(@hrforecast_datetime_format)})
-    else
-      req.set_form_data({'number' => value, 'mode' => @mode.to_s})
+    form_data = {
+      'number' => @enable_float_number ? value.to_f : value.to_i,
+      'mode' => @mode.to_s
+    }
+    if @datetime_format
+      form_data['datetime'] = Time.at(time).strftime(@datetime_format)
     end
+    req.set_form_data(form_data)
     req
   end
 

--- a/test/plugin/test_out_growthforecast.rb
+++ b/test/plugin/test_out_growthforecast.rb
@@ -119,20 +119,20 @@ class GrowthForecastOutputTest < Test::Unit::TestCase
       remove_prefix test
   ]
 
-  CONFIG_HRFORECAST_DATETIME_FORMAT = %[
+  CONFIG_DATETIME_FORMAT = %[
       gfapi_url  http://127.0.0.1:5125/api/
       service    service
       section    metrics
       name_keys  field
-      hrforecast_datetime_format %Y-%m-%d %H:%M:%S
+      datetime_format %Y-%m-%d %H:%M:%S %z
   ]
 
-  CONFIG_HRFORECAST_DATETIME_FORMAT_NON_KEEPALIVE = %[
+  CONFIG_DATETIME_FORMAT_NON_KEEPALIVE = %[
       gfapi_url  http://127.0.0.1:5125/api/
       service    service
       section    metrics
       name_keys  field
-      hrforecast_datetime_format %Y-%m-%d %H:%M:%S
+      datetime_format %Y-%m-%d
       keepalive  false
   ]
 
@@ -564,16 +564,16 @@ class GrowthForecastOutputTest < Test::Unit::TestCase
     assert_equal 'service_otherfield', v3rd[:name]
   end
 
-  # CONFIG_HRFORECAST_DATETIME_FORMAT = %[
+  # CONFIG_DATETIME = %[
   #     gfapi_url  http://127.0.0.1:5125/api/
   #     service    service
   #     section    metrics
   #     name_keys  field
-  #     hrforecast_datetime_format %Y-%m-%d %H:%M:%S
+  #     datetime_format %Y-%m-%d %H:%M:%S %z
   # ]
-  def test_hrforecast_datetime_format
+  def test_datetime_format
     time = Time.now()
-    d = create_driver(CONFIG_HRFORECAST_DATETIME_FORMAT, 'test.service')
+    d = create_driver(CONFIG_DATETIME_FORMAT, 'test.service')
     d.emit({'field' => 50}, time)
     d.run
 
@@ -581,21 +581,21 @@ class GrowthForecastOutputTest < Test::Unit::TestCase
     v1st = @posted[0]
 
     assert_equal 50, v1st[:data][:number]
-    assert_nil v1st[:data][:mode]
-    assert_equal time.strftime('%Y-%m-%d %H:%M:%S'), v1st[:data][:datetime]
+    assert_equal 'gauge', v1st[:data][:mode]
+    assert_equal time.strftime('%Y-%m-%d %H:%M:%S %z'), v1st[:data][:datetime]
   end
 
-  # CONFIG_HRFORECAST_DATETIME_FORMAT_NON_KEEPALIVE = %[
+  # CONFIG_DATETIME_FORMAT_NON_KEEPALIVE = %[
   #     gfapi_url  http://127.0.0.1:5125/api/
   #     service    service
   #     section    metrics
   #     name_keys  field
-  #     hrforecast_datetime_format %Y-%m-%d %H:%M:%S
+  #     datetime_format %Y-%m-%d
   #     keepalive  false
   # ]
-  def test_hrforecast_datetime_format_non_keepalive
+  def test_datetime_format_non_keepalive
     time = Time.now()
-    d = create_driver(CONFIG_HRFORECAST_DATETIME_FORMAT_NON_KEEPALIVE, 'test.service')
+    d = create_driver(CONFIG_DATETIME_FORMAT_NON_KEEPALIVE, 'test.service')
     d.emit({'field' => 50}, time)
     d.run
 
@@ -603,10 +603,9 @@ class GrowthForecastOutputTest < Test::Unit::TestCase
     v1st = @posted[0]
 
     assert_equal 50, v1st[:data][:number]
-    assert_nil v1st[:data][:mode]
-    assert_equal time.strftime('%Y-%m-%d %H:%M:%S'), v1st[:data][:datetime]
+    assert_equal 'gauge', v1st[:data][:mode]
+    assert_equal time.strftime('%Y-%m-%d'), v1st[:data][:datetime]
   end
-
 
 
 


### PR DESCRIPTION
this pull request is support HRForecast.

hrforecast_datetime_format option is special. if specified this option send current time formatted by this option as datetime POST parameter instead of mode parameter.
